### PR TITLE
Added option to limit model saving during training

### DIFF
--- a/RunGame.jl
+++ b/RunGame.jl
@@ -5,8 +5,9 @@ include("Training.jl")
 
 #setupnewtrainer("gaa", C4NN, emptyboard())
 trainer = AITrainer("gaa")
-#models =  Dict("main"=>newmodel(30))
+#models =  Dict("main"=>newmodel(50))
 #addnewmodels(trainer, models)
+#idofmodelset(trainer, Dict("main"=>1))
 #generatetrainingdata(trainer, Dict("main"=> 1), 1000, 1, 100, .8)
 
 #models = loadmodelset(trainer, Dict("main"=>1))
@@ -18,4 +19,4 @@ trainer = AITrainer("gaa")
 
 #runtestgames(trainer, [Dict("main"=>6), Dict("main"=>5)], 500, 1, 100, .6)
 
-runtrainingcycle(trainer, 8)
+runtrainingcycle(trainer, 3)


### PR DESCRIPTION
The model which has the lowest loss on the test data will always be saved. The user can also specify how frequently to save models (every epoch, every 10th epoch, etc.)