### PR TITLE
Sequential training cycles

### DIFF
--- a/RunGame.jl
+++ b/RunGame.jl
@@ -6,6 +6,11 @@ include("Training.jl")
 #setupnewtrainer("gaa", C4NN, emptyboard())
 trainer = AITrainer("gaa")
 #models =  Dict("main"=>newmodel(50))
+runtrainingcycles(trainer, 347, 1)
+
+
+
+#models =  Dict("main"=>newmodel(50))
 #addnewmodels(trainer, models)
 #idofmodelset(trainer, Dict("main"=>1))
 #generatetrainingdata(trainer, Dict("main"=> 1), 1000, 1, 100, .8)
@@ -19,4 +24,3 @@ trainer = AITrainer("gaa")
 
 #runtestgames(trainer, [Dict("main"=>6), Dict("main"=>5)], 500, 1, 100, .6)
 
-runtrainingcycle(trainer, 3)


### PR DESCRIPTION
You can now run multiple training cyles in a row. You can set a fixed number or allow it to run forever.

After each cycle, the performance of the new modelset vs the starting point is evaluated. If it is not better, the starting point is used again. If the new modelset is better, it is used as the starting point for the next cycle.

Graceful early stopping is handled by deleting the file "delete_to_stop_training_cycles.txt" [jank!].

Prettier printing of game playing progress.