### PR TITLE
Changed how model input sizes are tracked.

### DIFF
--- a/Connect.jl
+++ b/Connect.jl
@@ -29,8 +29,7 @@ struct C4Human <: Player
 end
 
  mutable struct C4NN <: Player
-    models::Dict{String, Union{Chain, Function}}
-    inputshapes::Dict{String, Tuple{Vararg{Int32, N} where N}}
+    models::Modelset
     headnode::SearchNode
     c_puct::Float64
     lookaheads::Int
@@ -69,7 +68,7 @@ end
 
 "Have a Neural Network AI select a move."
 function pickmove(gamestate::C4Game, player::C4NN)
-    explorefrom(player.headnode, player.c_puct, player.lookaheads, player.models, player.inputshapes)
+    explorefrom(player.headnode, player.c_puct, player.lookaheads, player.models)
     return bestmove(player.headnode, player.temperature)
 end
 

--- a/RunGame.jl
+++ b/RunGame.jl
@@ -4,12 +4,12 @@ include("Training.jl")
 
 toexcel(df::DataFrame) = clipboard(sprint(show, "text/tab-separated-values", df))
 
-path = "B:/JuliaProgramming/AI3"
-#setupnewtrainer(path, C4NN, emptyboard())
+path = "B:/JuliaProgramming/AI4"
+#setupnewtrainer(path, C4NN, emptyboard(); modelinputsizes=Dict("main"=>(84,)))
 #cp("B:/JuliaProgramming/defaults.json", "$path/defaults.json")
 trainer = AITrainer(path)
 
-#models =  Dict("main"=>convolutionalmodel(100))
+#models =  Dict("main"=>newmodel(100)[1])
 #addnewmodels(trainer, models)
 #t = createmodelset(trainer, [1])
 
@@ -17,8 +17,15 @@ startingmodelsetid = 1
 numberofdatasets = 1
 
 
-#runtrainingcycles(trainer, startingmodelsetid, Inf)
+#runtrainingcycles(trainer, 100, Inf)
 
-#modelsetloss(trainer, 1, [1,2,3,4])
 
-z = playtournament(trainer, [1, 2, 6, 9, 19, 30, 39, 55], 500)
+#t2 = AITrainer("B:/JuliaProgramming/AI4")
+
+"""
+p1 = createais(t2, [1, 26, 66]; lookaheads=150)
+p2 = createais(t2, [1, 26, 66]; lookaheads=500)
+pt = vcat(p1, p2)
+playtournament(pt, trainer.startstate, 600)
+#z=playtournament(trainer, [1,2, 100, 247], 400)
+"""

--- a/thoughts.txt
+++ b/thoughts.txt
@@ -10,3 +10,5 @@ Code issues
     - There is an issue with Zygote (part of Flux) when I try to add an L2 regularization term to the loss function. This term requires summing over the models parameters. For some reason I get the error "Mutating arrays is not supported". This didn't happen with an older verion of Julia/Flux. No clue what the problem is.
 
 
+- Should only a limited number of datasets be stored? This would limit the amount of space needed
+- Generated data can be used to jump start the trained process for new models. How should this be transferd? How is it stored in the database?


### PR DESCRIPTION
There is now a struct, Modelset, which contains the models for every game phase and the input sizes of those models. If an input size is not specified for a model, it is assumed that input data's shape does not need to be changed (this could be errouneous). The advantage of this change is to reduce the number of arguments passed to methods which use the models.

Minor change: when evaulating the quality of a newly trained modelset vs an old one, ties are counted as half for each player.